### PR TITLE
Attempt to parse yml and add Lob as an example

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,7 @@
 [submodule "examples/stripe/openapi"]
 	path = examples/stripe/openapi
 	url = https://github.com/stripe/openapi
+[submodule "examples/lob/lob-openapi"]
+	path = examples/lob/lob-openapi
+	url = https://github.com/lob/lob-openapi.git
+	branch = main

--- a/examples/lob/.formatter.exs
+++ b/examples/lob/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/examples/lob/.gitignore
+++ b/examples/lob/.gitignore
@@ -1,0 +1,26 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+lob-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/

--- a/examples/lob/README.md
+++ b/examples/lob/README.md
@@ -1,0 +1,21 @@
+# Lob
+
+**TODO: Add description**
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+by adding `lob` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:lob, "~> 0.1.0"}
+  ]
+end
+```
+
+Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
+and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
+be found at <https://hexdocs.pm/lob>.
+

--- a/examples/lob/lib/lob.ex
+++ b/examples/lob/lib/lob.ex
@@ -1,0 +1,10 @@
+defmodule Lob do
+  import OpenAPI
+
+  defopenapi_client(
+    path: Application.app_dir(:lob, "priv/lob-api-bundled.yml"),
+    base_url: "https://api.lob.com/v1",
+    only: ["/us_verifications"],
+    format: :yml
+  )
+end

--- a/examples/lob/mix.exs
+++ b/examples/lob/mix.exs
@@ -1,0 +1,27 @@
+defmodule Lob.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :lob,
+      version: "0.1.0",
+      elixir: "~> 1.13",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      {:openapi, path: "../.."}
+    ]
+  end
+end

--- a/examples/lob/mix.lock
+++ b/examples/lob/mix.lock
@@ -1,0 +1,5 @@
+%{
+  "jason": {:hex, :jason, "1.3.0", "fa6b82a934feb176263ad2df0dbd91bf633d4a46ebfdffea0c8ae82953714946", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "53fc1f51255390e0ec7e50f9cb41e751c260d065dcba2bf0d08dc51a4002c2ac"},
+  "yamerl": {:hex, :yamerl, "0.10.0", "4ff81fee2f1f6a46f1700c0d880b24d193ddb74bd14ef42cb0bcf46e81ef2f8e", [:rebar3], [], "hexpm", "346adb2963f1051dc837a2364e4acf6eb7d80097c0f53cbdc3046ec8ec4b4e6e"},
+  "yaml_elixir": {:hex, :yaml_elixir, "2.8.0", "c7ff0034daf57279c2ce902788ce6fdb2445532eb4317e8df4b044209fae6832", [:mix], [{:yamerl, "~> 0.8", [hex: :yamerl, repo: "hexpm", optional: false]}], "hexpm", "4b674bd881e373d1ac6a790c64b2ecb69d1fd612c2af3b22de1619c15473830b"},
+}

--- a/examples/lob/priv/lob-api-bundled.yml
+++ b/examples/lob/priv/lob-api-bundled.yml
@@ -1,0 +1,1 @@
+../lob-openapi/dist/lob-api-bundled.yml

--- a/examples/lob/test/lob_test.exs
+++ b/examples/lob/test/lob_test.exs
@@ -1,0 +1,29 @@
+defmodule LobTest do
+  use ExUnit.Case, async: true
+
+  test "it works" do
+    assert {:us_verification, 2} in Lob.__info__(:functions)
+  end
+end
+
+defmodule LobIntegrationTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :integration
+
+  test "it works" do
+    address = %{
+      city: "New York",
+      primary_line: "129 West 81st Street",
+      secondary_line: "Apt 5A",
+      state: "NY",
+      zip_code: "10024"
+    }
+
+    token = System.fetch_env!("LOB_TOKEN")
+
+    client = Lob.new(token: token)
+    {:ok, response} = Lob.us_verification(client, address)
+    assert response.body
+  end
+end

--- a/examples/lob/test/test_helper.exs
+++ b/examples/lob/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,8 @@ defmodule OpenAPI.MixProject do
 
   defp deps do
     [
-      {:jason, "~> 1.0"}
+      {:jason, "~> 1.0"},
+      {:yaml_elixir, "~> 2.8"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,5 @@
 %{
   "jason": {:hex, :jason, "1.2.2", "ba43e3f2709fd1aa1dce90aaabfd039d000469c05c56f0b8e31978e03fa39052", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "18a228f5f0058ee183f29f9eae0805c6e59d61c3b006760668d8d18ff0d12179"},
+  "yamerl": {:hex, :yamerl, "0.10.0", "4ff81fee2f1f6a46f1700c0d880b24d193ddb74bd14ef42cb0bcf46e81ef2f8e", [:rebar3], [], "hexpm", "346adb2963f1051dc837a2364e4acf6eb7d80097c0f53cbdc3046ec8ec4b4e6e"},
+  "yaml_elixir": {:hex, :yaml_elixir, "2.8.0", "c7ff0034daf57279c2ce902788ce6fdb2445532eb4317e8df4b044209fae6832", [:mix], [{:yamerl, "~> 0.8", [hex: :yamerl, repo: "hexpm", optional: false]}], "hexpm", "4b674bd881e373d1ac6a790c64b2ecb69d1fd612c2af3b22de1619c15473830b"},
 }


### PR DESCRIPTION
@wojtekmach, as usual, thanks for your work. I think a library like this is the best approach for dealing with third party apis. The burden for correctness can be passed to the third party api itself (follow the spec), not library maintainers trying to play catch up. With that said:

I was playing around with the repo and tried to add a service I was interested in using, Lob. They have an openapi file, but it is in yml (https://github.com/lob/lob-openapi/blob/main/dist/lob-api-bundled.yml). I imagine this will be a fairly common occurrence (I must admit I don't know much about the formats/specs) so maybe supporting that would be of interest.

Seems like it's almost working, when running the tests from within the lob application, I'm getting:

```
  1) test it works (LobIntegrationTest)
     test/lob_test.exs:14
     ** (CaseClauseError) no case clause matching: {:error, :invalid_request}
     code: {:ok, response} = Lob.us_verification(client, address)
     stacktrace:
       (openapi 0.1.0) lib/openapi.ex:151: OpenAPI.HTTPClient.HTTPC.request/5
       (openapi 0.1.0) lib/openapi.ex:93: OpenAPI.request/3
       test/lob_test.exs:26: (test)
```

I can give you the test token I'm using if you need/want, just ping me directly.

I tried inspecting this line `:httpc.request(method, request, [], body_format: :binary)`, that's where the error comes from.

My guess is that the conversion to json likely messed something up, but, the function was created correctly.

Any pointers on this one?

Thanks!